### PR TITLE
Fix template file path

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ def extract_data_from_pdf(pdf_path):
     return data
 
 def fill_template(data):
-    doc = Document("ШАБЛОН_GPT_ЧИСТЫЙ.docx")
+    doc = Document("ШАБЛОН_GPT_ЧИСТЫЙ (1).docx")
     for para in doc.paragraphs:
         for key, value in data.items():
             para.text = para.text.replace(f"<<{key}>>", value)


### PR DESCRIPTION
## Summary
- fix missing template path when filling Word document

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684219fb52bc832099b2d3aea90ea739